### PR TITLE
TWIN-94-Test-9-step-9-enabling-stored-view-in-turn-mode-does-not-look-exactly-as-it-should

### DIFF
--- a/Maker/Assets/Code/ViewManager.cs
+++ b/Maker/Assets/Code/ViewManager.cs
@@ -9,10 +9,11 @@ using UnityEngine.UI;
 public class ViewManager : MonoBehaviour, IDataPersistence
 {
     [System.Serializable]
-    public class View
-    {
+    public class View  {
         public string name;
-        public Vector3 positionCamera;
+        public float positionCamera_x;
+        public float positionCamera_y;
+        public float positionCamera_z;
         public float sizeCamera;
         public float pitch;
         public float yaw;
@@ -61,7 +62,9 @@ public class ViewManager : MonoBehaviour, IDataPersistence
         LeanPitchYaw control = body.GetComponent<LeanPitchYaw>();
         view.yaw = control.Yaw;
         view.pitch = control.Pitch;
-        view.positionCamera = mainCamera.transform.position;
+        view.positionCamera_x = mainCamera.transform.position.x;
+        view.positionCamera_y = mainCamera.transform.position.y;
+        view.positionCamera_z = mainCamera.transform.position.z;
         LeanPinchCamera camera = mainCamera.GetComponent<LeanPinchCamera>();
         view.sizeCamera = camera.Zoom;
         views.Add(view);
@@ -82,7 +85,7 @@ public class ViewManager : MonoBehaviour, IDataPersistence
         }
         else
         {
-            JsonUtility.FromJsonOverwrite(json, views);
+            JsonUtility.FromJsonOverwrite(json, this);
         }
         
         rebuild();
@@ -90,7 +93,7 @@ public class ViewManager : MonoBehaviour, IDataPersistence
 
     public void SaveData(ConfigData data)
     {
-        data.views = JsonUtility.ToJson(views);
+        data.views = JsonUtility.ToJson(this);
     }
     
     public GameObject relatedGameObject()
@@ -111,7 +114,7 @@ public class ViewManager : MonoBehaviour, IDataPersistence
         LeanPitchYaw control = body.GetComponent<LeanPitchYaw>();
         control.Yaw = view.yaw;
         control.Pitch =  view.pitch;
-        mainCamera.transform.position = view.positionCamera;
+        mainCamera.transform.position = new Vector3(view.positionCamera_x, view.positionCamera_y, view.positionCamera_z);
         LeanPinchCamera camera = mainCamera.GetComponent<LeanPinchCamera>();
         camera.Zoom = view.sizeCamera;
     }

--- a/Maker/Assets/Code/ViewManager.cs
+++ b/Maker/Assets/Code/ViewManager.cs
@@ -25,6 +25,8 @@ public class ViewManager : MonoBehaviour, IDataPersistence
     [SerializeField] public GameObject mainCamera;
     [SerializeField] public GameObject body;
     
+    private bool cameraEnabled = true;
+    
     public void build()
     {
         foreach (View view in views)
@@ -116,6 +118,8 @@ public class ViewManager : MonoBehaviour, IDataPersistence
         control.Pitch =  view.pitch;
         mainCamera.transform.position = new Vector3(view.positionCamera_x, view.positionCamera_y, view.positionCamera_z);
         LeanPinchCamera camera = mainCamera.GetComponent<LeanPinchCamera>();
+        cameraEnabled = camera.enabled;
+        camera.enabled = true;
         camera.Zoom = view.sizeCamera;
     }
     
@@ -127,6 +131,12 @@ public class ViewManager : MonoBehaviour, IDataPersistence
         mainCamera.transform.position = new Vector3(x: 0.0f, y: 0.5f, z: 1.0f);
         LeanPinchCamera camera = mainCamera.GetComponent<LeanPinchCamera>();
         camera.Zoom = 2.0f; 
+    }
+
+    void LateUpdate()
+    {
+        LeanPinchCamera camera = mainCamera.GetComponent<LeanPinchCamera>();
+        camera.enabled = cameraEnabled; 
     }
     
 }


### PR DESCRIPTION
Since we have to disable some components in Turn mode (to ensure that twin is not moved, no zoom) that restoring of a stored view did not work in turn mode.

When restoring a view, we enable the component in each case, and disable it after the next frame update if it was disabled initially


In addition I have solved the general problems with storing views by changing to storing of the complete view manager object and by cutting the Vector3 into three floats.