### PR TITLE
Twin 250 twin name error message is displayed in toast

### DIFF
--- a/Maker/Assets/Code/ConfigManager.cs
+++ b/Maker/Assets/Code/ConfigManager.cs
@@ -18,8 +18,8 @@ public class ConfigManager : MonoBehaviour
     public void newConfig()
     {
         string newTwinNameFromInput = GetTwinNameFromInput();
-        // getting newest input from the InputField
-        //if (CheckInputTwinName(newTwinNameFromInput)) {
+        // getting newest input
+
         if (CheckInput(newTwinNameFromInput))
         {
             // check if the new input is a already existing folder
@@ -32,7 +32,6 @@ public class ConfigManager : MonoBehaviour
             Debug.Log("Twin-Name-Test of New-button push failed!");
             //This is the new-Button because is create a completely new Twin
         }
-        
     }
     
     /*
@@ -42,9 +41,10 @@ public class ConfigManager : MonoBehaviour
     public void saveAsConfig()
     {
         string newTwinNameFromInput = GetTwinNameFromInput();
-        // getting newest input from the InputField
-        //if (CheckInputTwinName(newTwinNameFromInput)) {
-        if (CheckInput(newTwinNameFromInput)) { 
+        // getting newest input
+
+        if (CheckInput(newTwinNameFromInput))
+        { 
             // check if the new input is a already existing folder
             dataPersistenceManager.saveAsConfig(newTwinNameFromInput);
             inputField.transform.GetComponent<InputField>().text = "TwinName";  //resets the input Field
@@ -94,18 +94,17 @@ public class ConfigManager : MonoBehaviour
     }
 
     private bool CheckInput(string inputNameWithVersion) {
-        TwinNameValidator nameValidator = inputField.GetComponent<TwinNameValidator>();
-        //check twin name first an then put the versions on it... think about this again
+        TwinNameValidator nameValidator;
+
+        if (inputFieldVersion == null) {
+            //we adress the text in the error message toast with inputField/inputFieldVersion so we have to distinguish here
+
+            nameValidator = inputField.GetComponent<TwinNameValidator>();
+        } else {
+            nameValidator = inputFieldVersion.GetComponent<TwinNameValidator>();
+        }
 
         return nameValidator.validInput(inputNameWithVersion);
         //return true;
     }
-
-    private bool CheckInputTwinName(string inputForTwinName) {
-        // Here I want to acces the the component from the input field
-        // this component twinNameValidator 
-        TwinNameValidator nameValidator = inputField.GetComponent<TwinNameValidator>();
-        return true; //nameValidator.CheckInput(inputForTwinName);
-    }
-
 }

--- a/Maker/Assets/Code/FileManager.cs
+++ b/Maker/Assets/Code/FileManager.cs
@@ -130,7 +130,6 @@ public class FileManager : MonoBehaviour
     {
         dataManager.DeleteProfileData(profile);
         Refresh();
-        inputFieldName.GetComponent<TwinNameValidator>().ValidateInput();
     }
     
     private void Detail(string profile, string profile_raw, string version = "")

--- a/Maker/Assets/Code/TwinNameValidator.cs
+++ b/Maker/Assets/Code/TwinNameValidator.cs
@@ -19,8 +19,6 @@ public class TwinNameValidator : MonoBehaviour
     private void Start()
     {   
         nameInputField = this.GetComponent<InputField>();
-        //nameInputField.onValueChanged.AddListener(ValidateInput);
-        //nameInputField.onEndEdit.AddListener(ValidateInput);
     }
 
     public bool validInput(string twinNameWithVersion) {
@@ -56,37 +54,9 @@ public class TwinNameValidator : MonoBehaviour
         }
     }
 
-    //public void ValidateInput(string input)
-    //{
-    //    //EnableButtons(false);
-    //    if (CheckInput(input))
-    //    {
-    //        //input matches regex
-    //        DisplayErrorMessage("");
-    //        //EnableButtons(true);
-    //        Debug.Log("InputValid: " + input + ", Button interactable.");
-    //        //enable the button
-    //    }
-    //    else if (dataPersistenceManager.ExistsProfileId(input) && !input.Contains("."))
-    //    {
-    //        //dot is excluded because of ".", ".." and ".DS_Store" (shown when "ls -a" in folder: Maker)
-    //        //input is already a foldername
-    //        //EnableButtons(false);
-    //        DisplayErrorMessage("This twin name is already taken.");
-    //        Debug.Log("ExistingFolderName: " + input);
-    //    }
-    //    else
-    //    {
-    //        //EnableButtons(false);
-    //        DisplayErrorMessage("Twin name can only contain following characters: a-z, A-Z, 0-9 and \"_\", \"(\", \")\",\" - \". With length between 1 and 14.");
-    //        Debug.Log("InvalidUserInput: " + input);
-    //    }
-    //}
-
     public void ValidateInput()
     {
         string input = nameInputField.text;
-        //ValidateInput(input);
         validInput(input);
     }
 
@@ -106,21 +76,5 @@ public class TwinNameValidator : MonoBehaviour
             text.text = message;
         }
         notification.Pulse();
-    }
-
-    private void EnableButtons(bool isEnabled) {
-        GameObject safeButtonObject = this.transform.parent.Find("Save as").gameObject;
-        GameObject newButtonObject = this.transform.parent.Find("New").gameObject;
-        Button safeTwinButton = safeButtonObject.GetComponent<Button>();
-        Button newTwinButton = newButtonObject.GetComponent<Button>();
-        if (isEnabled)
-        {
-            safeTwinButton.interactable = true;
-            newTwinButton.interactable = true;
-        }
-        else {
-            safeTwinButton.interactable = false;
-            newTwinButton.interactable = false;
-        }
     }
 }

--- a/Maker/Assets/Code/TwinNameValidator.cs
+++ b/Maker/Assets/Code/TwinNameValidator.cs
@@ -3,10 +3,12 @@ using UnityEngine.UI;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
+using Lean.Gui;
 
 public class TwinNameValidator : MonoBehaviour
 { 
     [SerializeField] private DataPersistenceManager dataPersistenceManager;
+    [SerializeField] private LeanPulse notification;
 
     private InputField nameInputField;
     private static readonly string nameRegex = "^[a-zA-Z0-9_()-]{1,11}$";
@@ -96,9 +98,14 @@ public class TwinNameValidator : MonoBehaviour
     }
 
     private void DisplayErrorMessage(string errorMessage) {
-        GameObject errorMessageArea = this.transform.parent.Find("UserMessage").gameObject;
-        Text errorMessageDisplay = errorMessageArea.GetComponent<Text>();
-        errorMessageDisplay.text = errorMessage;
+        string message = errorMessage;
+
+        foreach (Text text in notification.gameObject.GetComponentsInChildren<Text>())
+            // in case there are more text boxes we write the error Message in every of them
+        {
+            text.text = message;
+        }
+        notification.Pulse();
     }
 
     private void EnableButtons(bool isEnabled) {

--- a/Maker/Assets/Code/TwinNameValidator.cs
+++ b/Maker/Assets/Code/TwinNameValidator.cs
@@ -14,6 +14,9 @@ public class TwinNameValidator : MonoBehaviour
     private static readonly string nameRegex = "^[a-zA-Z0-9_()-]{1,11}$";
     //Regex which only allows string that are made out of the characters a-z, A-Z, 0-9 and "_", "(", ")","-"
     //with the minimum length of 1 and the maximum length of 14
+    private static readonly string invalidNameMessge = "Twin name can only contain following characters: a-z, A-Z, 0-9 and \"_\", \"(\", \")\",\" - \". With length between 1 and 14.";
+    private static readonly string alreadyExistingNameMessage = "This Twin Name already exists.";
+
 
 
     private void Start()
@@ -21,36 +24,52 @@ public class TwinNameValidator : MonoBehaviour
         nameInputField = this.GetComponent<InputField>();
     }
 
-    public bool validInput(string twinNameWithVersion) {
-        if (twinNameWithVersion.Count(t => t == '.') != 1) {
+    public bool validInput(string twinNameWithVersion)
+    {
+        if (twinNameWithVersion.Count(t => t == '.') != 1)
+        {
             //there has to be exactly one dot in the name - between the twinName and its version
-            DisplayErrorMessage("Twin name can only contain following characters: a-z, A-Z, 0-9 and \"_\", \"(\", \")\",\" - \". With length between 1 and 14.");
+            DisplayMessage(invalidNameMessge);
             return false;
         }
         string[] twinName = twinNameWithVersion.Split('.');
 
-        if (dataPersistenceManager.ExistsProfileId(twinName[0]))
-            {
-                //if there is already a twin with this name - the version of this twin should be checked
-                if (twinName[1] != "000")
-                {
-                    DisplayErrorMessage("Twin name can only contain following characters: a-z, A-Z, 0-9 and \"_\", \"(\", \")\",\" - \". With length between 1 and 14.");
-                    return false;
-                } else {
-                //if twinName already exists we know that this twins name is valid
-                    return true;
-                }
-            }
-            else {
+        if (dataPersistenceManager.ExistsProfileId(/*twinName[0]*/twinNameWithVersion))
+        {
+            //if there is already a twin with this name - the version of this twin should be checked
+            //it could be the case that we have only a new version of an already existing twin
+            return IsValidVersion(twinName[1]);
+        }
+        else
+        {
             //if twin Name did not already exists it has to be checked!
             if (!CheckInput(twinName[0]))
             {
-                DisplayErrorMessage("Twin name can only contain following characters: a-z, A-Z, 0-9 and \"_\", \"(\", \")\",\" - \". With length between 1 and 14.");
+                DisplayMessage(invalidNameMessge);
                 return false;
             }
-            else {
+            else
+            {
                 return true;
             }
+        }
+    }
+
+    private bool IsValidVersion(string twinName)
+    {
+        if (twinName.Equals("000"))
+        {
+            // the Version is 000 so there was an attempt to create a twin with a name that already exists or the version was typed in manually which is
+            // not allowed so nothing happens
+            DisplayMessage(alreadyExistingNameMessage);
+            return false;
+        }
+        else
+        {
+            //if the version is unlike 000 it had to be altered by the user or the code so is should be correct? (set criteria for version input)
+
+            //!!!insert here actual check for valid version!!!
+            return true;
         }
     }
 
@@ -67,7 +86,7 @@ public class TwinNameValidator : MonoBehaviour
         // regex is white page regex so it accepts exactly when the name meets the naming conditions
     }
 
-    private void DisplayErrorMessage(string errorMessage) {
+    private void DisplayMessage(string errorMessage) {
         string message = errorMessage;
 
         foreach (Text text in notification.gameObject.GetComponentsInChildren<Text>())

--- a/Maker/Assets/Scenes/Maker Main.unity
+++ b/Maker/Assets/Scenes/Maker Main.unity
@@ -17797,6 +17797,13 @@ MonoBehaviour:
     meaning: 
     textTool: 
     description: 
+    group:
+      groupParts: []
+      group: {fileID: 0}
+      id: 
+      name: 
+      visible: 0
+      selected: 0
   references:
     version: 2
     RefIds: []
@@ -27968,6 +27975,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ResetApp
       objectReference: {fileID: 0}
+    - target: {fileID: 2336039277250485239, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
+      propertyPath: notification
+      value: 
+      objectReference: {fileID: 94311452}
     - target: {fileID: 2336039277250485239, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: dataPersistenceManager
       value: 

--- a/Maker/Assets/Scenes/Maker Main.unity
+++ b/Maker/Assets/Scenes/Maker Main.unity
@@ -26540,6 +26540,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
+    - target: {fileID: 2931942209416818475, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
+      propertyPath: notification
+      value: 
+      objectReference: {fileID: 94311452}
+    - target: {fileID: 2931942209416818475, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
+      propertyPath: dataPersistenceManager
+      value: 
+      objectReference: {fileID: 609004393}
     - target: {fileID: 4076088532309216022, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 


### PR DESCRIPTION
The new twin name will be checked when the button is pressed. If there has to occur an error Message this error message will now be shown with the toast. This also counts for the input of a new version of an already existing twin. Since we haven't discussed about naming regulations about the version there is still a small inconsistency but no general mistake.