### PR TITLE
TWIN-285-Translate-text-fields-in-SaveUI

### DIFF
--- a/Maker/Assets/Prefabs/GUI/Save UI.prefab
+++ b/Maker/Assets/Prefabs/GUI/Save UI.prefab
@@ -1528,7 +1528,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1787767312543281959, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
       propertyPath: m_StringReference.m_TableEntryReference.m_KeyId
-      value: 245990132015104
+      value: 5408222356692992
       objectReference: {fileID: 0}
     - target: {fileID: 1787767312543281959, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
       propertyPath: m_StringReference.m_TableReference.m_TableCollectionName

--- a/Maker/Assets/Prefabs/GUI/Save UI.prefab
+++ b/Maker/Assets/Prefabs/GUI/Save UI.prefab
@@ -329,6 +329,8 @@ MonoBehaviour:
   dataManager: {fileID: 0}
   inputFieldName: {fileID: 8726509804969779895}
   inputFieldVersion: {fileID: 0}
+  recorder: {fileID: 0}
+  notification: {fileID: 0}
   versionProfile: 
 --- !u!1 &3608362075497420424
 GameObject:
@@ -1351,7 +1353,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f77455691133a46d0bbe464849fe0d0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableValidation: 0
   dataPersistenceManager: {fileID: 0}
+  notification: {fileID: 0}
 --- !u!1 &8819207875687463437
 GameObject:
   m_ObjectHideFlags: 0
@@ -1522,6 +1526,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5299042047346597556}
     m_Modifications:
+    - target: {fileID: 1787767312543281959, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
+      propertyPath: m_StringReference.m_TableEntryReference.m_KeyId
+      value: 245990132015104
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787767312543281959, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
+      propertyPath: m_StringReference.m_TableReference.m_TableCollectionName
+      value: GUID:d12d872ce99d54eb4977c7b9daa8702f
+      objectReference: {fileID: 0}
     - target: {fileID: 4239298270747373838, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
       propertyPath: m_Text
       value: 'App Reset '

--- a/Maker/Assets/Prefabs/Scroll three buttons and three read only texts.prefab
+++ b/Maker/Assets/Prefabs/Scroll three buttons and three read only texts.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5912791910510974714}
   - component: {fileID: 7443920866728235290}
   - component: {fileID: 1512306203423549081}
+  - component: {fileID: 2992279104100928848}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -79,6 +80,46 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: Select
+--- !u!114 &2992279104100928848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 348602368196266846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56eb0353ae6e5124bb35b17aff880f16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StringReference:
+    m_TableReference:
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
+    m_TableEntryReference:
+      m_KeyId: 246010629578752
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  m_FormatArguments: []
+  m_UpdateString:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1512306203423549081}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Text, UnityEngine.UI
+        m_MethodName: set_text
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &494686080706996711
 GameObject:
   m_ObjectHideFlags: 0
@@ -767,6 +808,7 @@ GameObject:
   - component: {fileID: 3312922484724078803}
   - component: {fileID: 3964705129839793692}
   - component: {fileID: 2608782425546711326}
+  - component: {fileID: 591619994716768044}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -835,6 +877,46 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: Select
+--- !u!114 &591619994716768044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6346195984913231477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56eb0353ae6e5124bb35b17aff880f16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StringReference:
+    m_TableReference:
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
+    m_TableEntryReference:
+      m_KeyId: 246010629578752
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  m_FormatArguments: []
+  m_UpdateString:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2608782425546711326}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Text, UnityEngine.UI
+        m_MethodName: set_text
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &7453838321871361816
 GameObject:
   m_ObjectHideFlags: 0
@@ -1370,6 +1452,7 @@ GameObject:
   - component: {fileID: 8550013890822620362}
   - component: {fileID: 8550013890822620372}
   - component: {fileID: 8550013890822620363}
+  - component: {fileID: 7755370698088619690}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -1438,6 +1521,46 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: Delete
+--- !u!114 &7755370698088619690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8550013890822620361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56eb0353ae6e5124bb35b17aff880f16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StringReference:
+    m_TableReference:
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
+    m_TableEntryReference:
+      m_KeyId: 245775882772480
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  m_FormatArguments: []
+  m_UpdateString:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8550013890822620363}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Text, UnityEngine.UI
+        m_MethodName: set_text
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &8639815392122440219
 GameObject:
   m_ObjectHideFlags: 0

--- a/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
+++ b/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
@@ -112,7 +112,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Key: APP_RESET
+    m_Key: RESET
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752
@@ -149,6 +149,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 246306030215168
     m_Key: _STICKER_
+    m_Metadata:
+      m_Items: []
+  - m_Id: 5408222356692992
+    m_Key: APP_RESET
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
+++ b/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
@@ -112,7 +112,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Key: RESET
+    m_Key: APP_RESET
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752

--- a/Maker/Assets/Tables/TwinLocalTables_de.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_de.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: "App zur\xFCcksetzen"
+    m_Localized: "Zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752
@@ -154,6 +154,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 246306030215168
     m_Localized: ' Aufkleber '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 5408222356692992
+    m_Localized: "App zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   references:

--- a/Maker/Assets/Tables/TwinLocalTables_de.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_de.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: "Zur\xFCcksetzen"
+    m_Localized: "App zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752

--- a/Maker/Assets/Tables/TwinLocalTables_demed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_demed.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: "App zur\xFCcksetzen"
+    m_Localized: "Zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752
@@ -154,6 +154,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 246306030215168
     m_Localized: ' Aufkleber '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 5408222356692992
+    m_Localized: "App zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   references:

--- a/Maker/Assets/Tables/TwinLocalTables_demed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_demed.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: "Zur\xFCcksetzen"
+    m_Localized: "App zur\xFCcksetzen"
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752

--- a/Maker/Assets/Tables/TwinLocalTables_en.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_en.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: Reset App
+    m_Localized: Reset
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752
@@ -154,6 +154,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 246306030215168
     m_Localized: ' Sticker '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 5408222356692992
+    m_Localized: Reset App
     m_Metadata:
       m_Items: []
   references:

--- a/Maker/Assets/Tables/TwinLocalTables_en.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_en.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: Reset
+    m_Localized: Reset App
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752

--- a/Maker/Assets/Tables/TwinLocalTables_enmed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_enmed.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: Reset App
+    m_Localized: Reset
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752
@@ -154,6 +154,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 246306030215168
     m_Localized: ' Injuries '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 5408222356692992
+    m_Localized: Reset App
     m_Metadata:
       m_Items: []
   references:

--- a/Maker/Assets/Tables/TwinLocalTables_enmed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_enmed.asset
@@ -121,7 +121,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245990132015104
-    m_Localized: Reset
+    m_Localized: Reset App
     m_Metadata:
       m_Items: []
   - m_Id: 246010629578752


### PR DESCRIPTION
Added new localization table entry for "reset app".
Translated SaveUI, that's only "select", "delete" and "reset app". Because "Wählen" and "Entfernen" are much longer, the words overlap. I will create a bug ticket and fix the layout another time. 