### PR TITLE
TWIN-307-Settings-sprite-is-missing

### DIFF
--- a/Maker/Assets/Prefabs/GUI top.prefab
+++ b/Maker/Assets/Prefabs/GUI top.prefab
@@ -2425,7 +2425,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 00d873e9519954e73b7e2fa115b7c5de, type: 3}
+  m_Sprite: {fileID: 21300000, guid: acdd5133ff65f44ef93a41030aa42730, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1


### PR DESCRIPTION
sprite for settings ui in gui top was missing, added it again in gui top prefab