### PR TITLE
Twin-305-store-selected-language-in-config

### DIFF
--- a/Maker/Assets/Code/DataPersistence/Data/ConfigData.cs
+++ b/Maker/Assets/Code/DataPersistence/Data/ConfigData.cs
@@ -21,6 +21,7 @@ public class ConfigData
     public string name;
     public string version;
     public string updated;
+    public int languageID;
 
     public ConfigData(string modelName, string modelVersion = "")
     {
@@ -38,5 +39,6 @@ public class ConfigData
         version = modelVersion;
         name = modelName;
         updated = new DateTime(1969, 4,25, 10,10,00).ToString();
+        languageID = 0;
     }
 }

--- a/Maker/Assets/Code/Localization/LanguageSelector.cs
+++ b/Maker/Assets/Code/Localization/LanguageSelector.cs
@@ -44,7 +44,6 @@ public class LanguageSelector : MonoBehaviour, IDataPersistence
         } 
         
         LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales[languageID];
-        
     }
 
     public void SaveData(ConfigData data)
@@ -55,5 +54,13 @@ public class LanguageSelector : MonoBehaviour, IDataPersistence
             languageID = 0;
         }
         data.languageID = languageID;
+    }
+
+    public int GetLanguageID() {
+        if (languageID == null)
+        {
+            return 0;
+        }
+        return languageID;
     }
 }

--- a/Maker/Assets/Code/Localization/LanguageSelector.cs
+++ b/Maker/Assets/Code/Localization/LanguageSelector.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 using UnityEngine.Localization.Settings;
@@ -8,7 +7,7 @@ using UnityEngine.Localization.Settings;
 public class LanguageSelector : MonoBehaviour, IDataPersistence   
 {
     [SerializeField] public bool persistent = true;
-    private bool active = false; //makes sure that coroutine is not called more than once
+    private bool isMyCoroutineActive = false; //makes sure that coroutine is not called more than once
     private int languageID;
 
     public GameObject relatedGameObject()
@@ -18,7 +17,7 @@ public class LanguageSelector : MonoBehaviour, IDataPersistence
 
     public void ChangeLocale(int localeID)
     {
-        if (active == true)
+        if (isMyCoroutineActive == true)
         {
             return;
         }
@@ -27,23 +26,25 @@ public class LanguageSelector : MonoBehaviour, IDataPersistence
 
     IEnumerator SetLocale(int localeID)
     {
-        active = true;
+        isMyCoroutineActive = true;
         yield return LocalizationSettings.InitializationOperation; //makes sure that localization is loaded and ready to use
         LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales[localeID];
         languageID = localeID;
-        active = false;
+        isMyCoroutineActive = false;
 
     }
-    
+
     public void LoadData(ConfigData data)
     {
         if (persistent == false) return;
         languageID = data.languageID;
-        if (languageID == null)
+        if (data.languageID == null)
         {
             languageID = 0;
-        }
-        StartCoroutine(SetLocale(languageID));//error here because SettingManager is inactiv!
+        } 
+        
+        LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales[languageID];
+        
     }
 
     public void SaveData(ConfigData data)

--- a/Maker/Assets/Code/Localization/LanguageSelector.cs
+++ b/Maker/Assets/Code/Localization/LanguageSelector.cs
@@ -4,9 +4,17 @@ using UnityEngine;
 
 using UnityEngine.Localization.Settings;
 
-public class LanguageSelector : MonoBehaviour
+
+public class LanguageSelector : MonoBehaviour, IDataPersistence   
 {
+    [SerializeField] public bool persistent = true;
     private bool active = false; //makes sure that coroutine is not called more than once
+    private int languageID;
+
+    public GameObject relatedGameObject()
+    {
+        return this.gameObject;
+    }
 
     public void ChangeLocale(int localeID)
     {
@@ -22,7 +30,29 @@ public class LanguageSelector : MonoBehaviour
         active = true;
         yield return LocalizationSettings.InitializationOperation; //makes sure that localization is loaded and ready to use
         LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales[localeID];
+        languageID = localeID;
         active = false;
 
+    }
+    
+    public void LoadData(ConfigData data)
+    {
+        if (persistent == false) return;
+        languageID = data.languageID;
+        if (languageID == null)
+        {
+            languageID = 0;
+        }
+        StartCoroutine(SetLocale(languageID));//error here because SettingManager is inactiv!
+    }
+
+    public void SaveData(ConfigData data)
+    {
+        if (persistent == false) return;
+        if (languageID == null)
+        {
+            languageID = 0;
+        }
+        data.languageID = languageID;
     }
 }

--- a/Maker/Assets/Code/SettingsManager.cs
+++ b/Maker/Assets/Code/SettingsManager.cs
@@ -8,7 +8,12 @@ public class SettingsManager : MonoBehaviour
 {
     [SerializeField] private DataPersistenceManager dataPersistenceManager;
     [SerializeField] private TMP_Dropdown dropdown;
-    private bool active = false; //makes sure that coroutine is not called more than once
+    private LanguageSelector languageSelector;
+
+    void Start()
+    {
+        Debug.Log("Settings Manager started!");
+    }
 
     public void ResetApp()
     {
@@ -19,24 +24,8 @@ public class SettingsManager : MonoBehaviour
     public void GetSelectedLanguage() {
         //localeID is SetFontSize bu order of the languages  in the localization table
         // if options in drop down menu are in the same order as the languages in the localization table, we can directly parse the dopdown value as the localeID
-        ChangeLocale(dropdown.value);
-    }
 
-    public void ChangeLocale(int localeID)
-    {
-        if (active == true)
-        {
-            return;
-        }
-        StartCoroutine(SetLocale(localeID));
-    }
-
-    IEnumerator SetLocale(int localeID)
-    {
-        active = true;
-        yield return LocalizationSettings.InitializationOperation; //makes sure that localization is loaded and ready to use
-        LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales[localeID];
-        active = false;
-
+        languageSelector = this.gameObject.GetComponent<LanguageSelector>();
+        languageSelector.ChangeLocale(dropdown.value);
     }
 }

--- a/Maker/Assets/Code/SettingsManager.cs
+++ b/Maker/Assets/Code/SettingsManager.cs
@@ -15,6 +15,14 @@ public class SettingsManager : MonoBehaviour
         Debug.Log("Settings Manager started!");
     }
 
+    public void OnEnable() {
+        languageSelector = this.gameObject.GetComponent<LanguageSelector>();
+        int languageID = languageSelector.GetLanguageID();
+        dropdown.value = languageID;
+        //update drop menu here
+        Debug.Log("Current languageID: " + languageID);
+    }
+
     public void ResetApp()
     {
         dataPersistenceManager.ResetApp();

--- a/Maker/Assets/Prefabs/GUI/Settings UI.prefab
+++ b/Maker/Assets/Prefabs/GUI/Settings UI.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 858734131066933951}
   - component: {fileID: 2528477133427624409}
+  - component: {fileID: 8092866397685728304}
   m_Layer: 5
   m_Name: SettingsManager
   m_TagString: Untagged
@@ -50,6 +51,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dataPersistenceManager: {fileID: 0}
   dropdown: {fileID: 6570167850992355447}
+--- !u!114 &8092866397685728304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3752414550353126931}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09d44cfac601c436c9f266ccb5a9dbbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  persistent: 1
 --- !u!1 &6199921708383996008
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Every language has their own languageID which is now stored in the config. The standard value is 0 for english. If you change the language and close and reopen the app, the language should be the same, as the time you closed the app.