### PR TITLE
TWIN-341-rudimentary-screenshot-process-code-documentation

### DIFF
--- a/Maker/Assets/Code/PartsScreenshotProcess.cs
+++ b/Maker/Assets/Code/PartsScreenshotProcess.cs
@@ -14,9 +14,15 @@ namespace Code
         private PartManager.PartData nextPart;
         private bool isProcessingPart = false;
 
+        public override ProcessResult Execute(string variant = "")
+        {
+            StartCoroutine(ProcessParts());
+            return new ProcessResult();
+        }
+        
         private IEnumerator ProcessParts()
         {
-            Debug.Log("Start Parts Screenshots");
+            Debug.Log("ProcessParts: Start Parts Screenshots");
             viewManager = getViewmanager();
             SceneManagement.View currentView = viewManager.shootView();
             recorder = getRecorder();
@@ -53,15 +59,17 @@ namespace Code
             }
         }
 
-        public override ProcessResult Execute(string variant = "")
+        public override ProcessResult ExecuteSync(string variant = "")
         {
-            StartCoroutine(ProcessParts());
+            Debug.Log("Process status: Start PartsScreenshotProcess");
+            StartCoroutine(ExecuteCoroutine());
+            Debug.Log("Process status: End PartsScreenshotProcess");
             return new ProcessResult();
         }
         
         private IEnumerator ExecuteCoroutine()
         {
-            Debug.Log("Start Parts Screenshots");
+            Debug.Log("ExecuteCoroutine: Start Parts Screenshots");
             viewManager = getViewmanager();
             SceneManagement.View currentView = viewManager.shootView();
             recorder = getRecorder();
@@ -91,14 +99,6 @@ namespace Code
             viewManager.select(currentView);
             yield return new WaitForEndOfFrame();
             OnExecuteCompleted();
-        }
-        
-        public override ProcessResult ExecuteSync(string variant = "")
-        {
-            Debug.Log("Process status: Start PartsScreenshotProcess");
-            StartCoroutine(ExecuteCoroutine());
-            Debug.Log("Process status: End PartsScreenshotProcess");
-            return new ProcessResult();
         }
 
         private void Update()

--- a/Maker/Assets/Code/PartsScreenshotProcess.cs
+++ b/Maker/Assets/Code/PartsScreenshotProcess.cs
@@ -4,6 +4,11 @@ using UnityEngine;
 
 namespace Code
 {
+    /// <summary>
+    /// Handles the process of taking screenshots for parts in a scene.
+    /// Manages the execution flow, including preparing data, iterating through parts,
+    /// and capturing screenshots using a recorder.
+    /// </summary>
     public class PartsScreenshotProcess : ProcessSync
     {
         private ViewManager viewManager;
@@ -59,6 +64,14 @@ namespace Code
             }
         }
 
+        /// <summary>
+        /// Executes the coroutine responsible for capturing screenshots of all parts in the scene.
+        /// This method handles the following tasks:
+        /// - Iterates through all groups and their respective parts.
+        /// - Waits for each part to finish processing before moving to the next. Update()-function starts process for next part when process of part before is completed
+        /// - Resets and cleans up after processing is complete.
+        /// - Posts the captured data and restores the original view.
+        /// </summary>
         public override ProcessResult ExecuteSync(string variant = "")
         {
             Debug.Log("Process status: Start PartsScreenshotProcess");
@@ -88,6 +101,7 @@ namespace Code
                     nextGroup = group;
                     nextPart = part;
                     yield return StartCoroutine(WaitForIdle());
+                    // waits until Update() gets called and starts coroutine to take screenshot of this part
                 }
             }
 

--- a/Maker/Assets/Code/SequenceProcess.cs
+++ b/Maker/Assets/Code/SequenceProcess.cs
@@ -5,6 +5,13 @@ using System;
 
 namespace Code
 {
+    /// <summary>
+    /// A process that executes a sequence of synchronized processes asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// This class manages a list of processes and ensures they are executed in order, 
+    /// waiting for each process to complete before starting the next (synchronized).
+    /// </remarks>
     public class SequenceProcess : Process
     {
         [SerializeField]
@@ -32,6 +39,17 @@ namespace Code
             await taskCompletionSource.Task;
         }
         
+        /// <summary>
+        /// Executes a single process asynchronously and waits for its completion.
+        /// </summary>
+        /// <param name="process">The process to be executed, represented by a <see cref="ProcessSync"/> object.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the asynchronous operation. The task completes when the process signals its completion.
+        /// </returns>
+        /// <remarks>
+        /// This method uses a <see cref="TaskCompletionSource{TResult}"/> to await the completion of the process. 
+        /// It subscribes to the <c>ExecuteCompleted</c> event of the process and ensures proper unsubscription to avoid memory leaks.
+        /// </remarks>
         private async Task ExecuteProcessAsync(ProcessSync process)
         {
             var taskCompletionSource = new TaskCompletionSource<bool>();


### PR DESCRIPTION
restructured a few functions and added comments for important parts

We should talk about the Execute Function in PartsScreenshotProcess - we didn't find the caller of this function while debugging(Debug Logs from this function are't printed too).