### PR TITLE
TWIN-348-add-functionality-to-new-version-button-in-MainUI

### DIFF
--- a/Maker/Assets/Code/ConfigManager.cs
+++ b/Maker/Assets/Code/ConfigManager.cs
@@ -1,6 +1,6 @@
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
+using UnityEngine.Localization;
 using UnityEngine.UI;
 
 public class ConfigManager : MonoBehaviour
@@ -10,15 +10,45 @@ public class ConfigManager : MonoBehaviour
     [SerializeField] private FileManager fileManager;
     [SerializeField] private GameObject inputField;
     [SerializeField] private GameObject inputFieldVersion;
+    [SerializeField] private LocalizedString dateFormat;
 
     /*
      * This methode is responsible, if the button newConfig is pressed in Twin Mode.
-     * This Button creates a complete new Twin
      */
-    public void newConfig()
+    public void newConfigFromInput()
     {
-        string newTwinNameFromInput = GetTwinNameFromInput();
         // getting newest input
+        string newTwinNameFromInput = GetTwinNameFromInput();
+        newConfig(newTwinNameFromInput);
+    }
+
+    /*
+     * This methode is responsible, if the button New Version is pressed in MainUI or TurnUI
+     */
+    public void newConfigFromMainMenu()
+    {
+        //get time
+        DateTime currentDate = DateTime.Now; // getting current Time to put into version input field
+
+        // format the date to current localization settings
+        LocalizedString formattedLocalizedString = DateFormatter.formatDate(currentDate, dateFormat);
+
+        String twinAndVersion = dataPersistenceManager.selectedProfileId;
+        string[] splitTwinName = twinAndVersion.Split('.');
+        String twin = splitTwinName[0];
+        twin += "." + formattedLocalizedString.GetLocalizedString();
+        Debug.Log("Version from Input: " + formattedLocalizedString.GetLocalizedString() + ".");
+
+        newConfig(twin); 
+
+    }
+
+
+    /*
+     * This method creates a complete new Twin
+     */
+    private void newConfig(string newTwinNameFromInput)
+    {
 
         if (CheckInput(newTwinNameFromInput))
         {
@@ -29,7 +59,6 @@ public class ConfigManager : MonoBehaviour
             InteractionController.EnableMode("Main");
         } else {
             Debug.Log("Twin-Name-Test of New-button push failed!");
-            //This is the new-Button because is create a completely new Twin
         }
     }
     

--- a/Maker/Assets/Prefabs/GUI/Save UI.prefab
+++ b/Maker/Assets/Prefabs/GUI/Save UI.prefab
@@ -402,9 +402,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 34455528108144745}
         m_TargetAssemblyTypeName: ConfigManager, Assembly-CSharp
-        m_MethodName: newConfig
+        m_MethodName: newConfigFromInput
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -693,6 +693,18 @@ MonoBehaviour:
   fileManager: {fileID: 0}
   inputField: {fileID: 0}
   inputFieldVersion: {fileID: 0}
+  dateFormat:
+    m_TableReference:
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
+    m_TableEntryReference:
+      m_KeyId: 5390009120055296
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &5183104375465273792
 GameObject:
   m_ObjectHideFlags: 0
@@ -1664,9 +1676,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 34455528108144745}
         m_TargetAssemblyTypeName: ConfigManager, Assembly-CSharp
-        m_MethodName: saveAsConfig
+        m_MethodName: newConfigFromInput
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1844,6 +1856,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4684022689559253548, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 34455528108144745}
     - target: {fileID: 4684022689559253548, guid: 2af735dd9f1574faa9327ea9cdce07c3, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ResetApp

--- a/Maker/Assets/Prefabs/GUI/Twin versions UI.prefab
+++ b/Maker/Assets/Prefabs/GUI/Twin versions UI.prefab
@@ -119,6 +119,18 @@ MonoBehaviour:
   fileManager: {fileID: 0}
   inputField: {fileID: 0}
   inputFieldVersion: {fileID: 0}
+  dateFormat:
+    m_TableReference:
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
+    m_TableEntryReference:
+      m_KeyId: 5390009120055296
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &539008734881843823
 GameObject:
   m_ObjectHideFlags: 0
@@ -817,7 +829,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 8329449449957153508}
         m_TargetAssemblyTypeName: ConfigManager, Assembly-CSharp
         m_MethodName: saveAsConfig
         m_Mode: 1
@@ -1103,8 +1115,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 423, y: 5}
-  m_SizeDelta: {x: 225, y: 60}
+  m_AnchoredPosition: {x: 500, y: 5}
+  m_SizeDelta: {x: 350, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4057376346681269004
 CanvasRenderer:
@@ -1540,9 +1552,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 8329449449957153508}
         m_TargetAssemblyTypeName: ConfigManager, Assembly-CSharp
-        m_MethodName: newConfig
+        m_MethodName: newConfigFromInput
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Maker/Assets/Scenes/Maker Main.unity
+++ b/Maker/Assets/Scenes/Maker Main.unity
@@ -324,17 +324,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7480330371857051126, guid: 570be41bf7ac241c2a2ff15fbbbcca67, type: 3}
   m_PrefabInstance: {fileID: 955790828}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &74087245 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 34455528108144745, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-  m_PrefabInstance: {fileID: 7284427835652978919}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f44828d30c9d4336aba5fa05d5837d5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &78842104
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8302,6 +8291,34 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5513377015833497343}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1763323387721520155, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 2076507035649952163, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 5
@@ -8375,6 +8392,34 @@ PrefabInstance:
       value: Help
       objectReference: {fileID: 0}
     - target: {fileID: 3175384858532305451, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3342757634067188594, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
@@ -8591,6 +8636,34 @@ PrefabInstance:
       value: Help
       objectReference: {fileID: 0}
     - target: {fileID: 8155194172836185159, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8313633966721111326, guid: 7eea81e5c72174b61bc18200fd8312d7, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
@@ -11759,6 +11832,34 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 704423225385398847, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 1196508745669199213, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
@@ -12123,6 +12224,34 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 4602067680376843606, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 4623868865924332730, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -12250,6 +12379,34 @@ PrefabInstance:
     - target: {fileID: 5924895665801641481, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1797849470}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: newConfigFromMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ConfigManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6123408270324788307, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 6561193786773072610, guid: 51003683620f840d6bc14bf3f12b975b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -16125,14 +16282,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 4336700730907393418, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1797849470}
-    - target: {fileID: 4336700730907393418, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: saveAsConfig
-      objectReference: {fileID: 0}
     - target: {fileID: 4912950541163882178, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
       propertyPath: dataManager
       value: 
@@ -16153,14 +16302,6 @@ PrefabInstance:
       propertyPath: dataPersistenceManager
       value: 
       objectReference: {fileID: 609004393}
-    - target: {fileID: 5570546650419907792, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1797849470}
-    - target: {fileID: 5570546650419907792, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: newConfig
-      objectReference: {fileID: 0}
     - target: {fileID: 6552543984901105118, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -16285,6 +16426,10 @@ PrefabInstance:
       propertyPath: dataPersistenceManager
       value: 
       objectReference: {fileID: 609004393}
+    - target: {fileID: 8329449449957153508, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
+      propertyPath: dateFormat.m_TableEntryReference.m_KeyId
+      value: 5390009120055296
+      objectReference: {fileID: 0}
     - target: {fileID: 8960526092882599699, guid: 1856de562a7fc4f6cb35a0074e3ed04a, type: 3}
       propertyPath: m_Name
       value: Twin versions UI
@@ -17813,6 +17958,10 @@ PrefabInstance:
       propertyPath: dataPersistenceManager
       value: 
       objectReference: {fileID: 609004393}
+    - target: {fileID: 34455528108144745, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
+      propertyPath: dateFormat.m_TableEntryReference.m_KeyId
+      value: 5390009120055296
+      objectReference: {fileID: 0}
     - target: {fileID: 378354880925425622, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: folderHash
       value: 
@@ -17844,14 +17993,6 @@ PrefabInstance:
     - target: {fileID: 1297870844305532283, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
       value: Settings
-      objectReference: {fileID: 0}
-    - target: {fileID: 2239636238829624043, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 74087245}
-    - target: {fileID: 2239636238829624043, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ResetApp
       objectReference: {fileID: 0}
     - target: {fileID: 2336039277250485239, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: notification
@@ -17896,14 +18037,6 @@ PrefabInstance:
     - target: {fileID: 3697226621704615350, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -40
-      objectReference: {fileID: 0}
-    - target: {fileID: 4499625796352721981, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 74087245}
-    - target: {fileID: 4499625796352721981, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: saveAsConfig
       objectReference: {fileID: 0}
     - target: {fileID: 4599264887613755153, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: m_Pivot.x
@@ -18008,14 +18141,6 @@ PrefabInstance:
     - target: {fileID: 4654117513137014403, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
-      objectReference: {fileID: 0}
-    - target: {fileID: 5209272628932904194, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 74087245}
-    - target: {fileID: 5209272628932904194, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: newConfig
       objectReference: {fileID: 0}
     - target: {fileID: 6250599881926092517, guid: 9b80a04d4e56a46c7a1b0f3528542243, type: 3}
       propertyPath: m_Enabled

--- a/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
+++ b/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
@@ -144,7 +144,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 246218599948288
-    m_Key: DATETIME_SMART
+    m_Key: DATE_TIME_SMART
     m_Metadata:
       m_Items: []
   - m_Id: 246306030215168
@@ -152,7 +152,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 5390009120055296
-    m_Key: DATE_SMART
+    m_Key: DATE_VERSION_SMART
     m_Metadata:
       m_Items: []
   - m_Id: 5408222356692992

--- a/Maker/Assets/Tables/TwinLocalTables_de.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_de.asset
@@ -157,7 +157,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 5390009120055296
-    m_Localized: '{0:dd-MM-yyyy}'
+    m_Localized: '{0:MM-dd-yy-mmss}'
     m_Metadata:
       m_Items:
       - rid: 5071356925864312835

--- a/Maker/Assets/Tables/TwinLocalTables_demed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_demed.asset
@@ -157,7 +157,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 5390009120055296
-    m_Localized: '{0:dd-MM-yyyy}'
+    m_Localized: '{0:MM-dd-yy-mmss}'
     m_Metadata:
       m_Items:
       - rid: 5071356925864312836

--- a/Maker/Assets/Tables/TwinLocalTables_en.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_en.asset
@@ -157,7 +157,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 5390009120055296
-    m_Localized: '{0:MM-dd-yyyy}'
+    m_Localized: '{0:MM-dd-yy-mmss}'
     m_Metadata:
       m_Items:
       - rid: 5071356925864312833

--- a/Maker/Assets/Tables/TwinLocalTables_enmed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_enmed.asset
@@ -157,7 +157,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 5390009120055296
-    m_Localized: '{0:MM-dd-yyyy}'
+    m_Localized: '{0:MM-dd-yy-mmss}'
     m_Metadata:
       m_Items:
       - rid: 5071356925864312834


### PR DESCRIPTION
- added new method to ConfigManager.cs that adds a new version with automatic name
- changed format of date used for naming twins and versions to avoid naming collisions
- changes in MakerMain: ConfigManager is a component of Twin versions UI -> Bottom -> Buttons -> config. I dragged the game object into the onClick events of the instances of MainUI and TurnUI to call ConfigManager.newConfigFromMainMenu()