### PR TITLE
TWIN-361-add-localization-entry-for-new-view-name

### DIFF
--- a/Maker/Assets/Code/ViewManager.cs
+++ b/Maker/Assets/Code/ViewManager.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using Lean.Common;
 using Lean.Touch;
 using UnityEngine.UI;
+using UnityEngine.Localization.Components;
+using UnityEngine.Events;
 
 public class ViewManager : SceneManagement, IDataPersistence
 {
@@ -23,15 +25,40 @@ public class ViewManager : SceneManagement, IDataPersistence
 
     public void build()
     {
-        
-        displayView(getDefaultView());
+
+        AddDefaultView();
         foreach (View view in views)
         {
             displayView(view);
         }
     }
 
+    private GameObject AddDefaultView() {
+        //create defaultView and instance of the prefab representing the defaultView in the UI
+        View defaultView = getDefaultView();
+        GameObject defaultViewToDisplay = displayView(defaultView);
+
+        //to update the name from the DefaultView accoringly to the current locale we need access to the localizeEvents
+        Transform viewNameDefaultView = defaultViewToDisplay.transform.Find("ReadOnlyMode").Find("Text Background").Find("ViewName");
+        LocalizeStringEvent localizeEvent = viewNameDefaultView.GetComponent<LocalizeStringEvent>();
+        localizeEvent.StringReference.SetReference("TwinLocalTables", "DEFAULT_VIEW");
+
+
+        // configure UnityEventto set Text
+        UnityAction<string> updateText = (string localizedText) =>
+        {
+            viewNameDefaultView.GetComponent<Text>().text = localizedText;
+        };
+
+        localizeEvent.OnUpdateString.AddListener(updateText);
+
+        localizeEvent.RefreshString();
+
+        return defaultViewToDisplay;
+    }
+
     public View getDefaultView() {
+
         View defaultView = new View();
         defaultView.name = "Default View";
         defaultView.positionCamera_x = 0.0f;

--- a/Maker/Assets/Code/ViewManager.cs
+++ b/Maker/Assets/Code/ViewManager.cs
@@ -38,21 +38,10 @@ public class ViewManager : SceneManagement, IDataPersistence
         View defaultView = getDefaultView();
         GameObject defaultViewToDisplay = displayView(defaultView);
 
-        //to update the name from the DefaultView accoringly to the current locale we need access to the localizeEvents
+        //to update the name from the DefaultView we need access to the localizeEvents
         Transform viewNameDefaultView = defaultViewToDisplay.transform.Find("ReadOnlyMode").Find("Text Background").Find("ViewName");
-        LocalizeStringEvent localizeEvent = viewNameDefaultView.GetComponent<LocalizeStringEvent>();
-        localizeEvent.StringReference.SetReference("TwinLocalTables", "DEFAULT_VIEW");
 
-
-        // configure UnityEventto set Text
-        UnityAction<string> updateText = (string localizedText) =>
-        {
-            viewNameDefaultView.GetComponent<Text>().text = localizedText;
-        };
-
-        localizeEvent.OnUpdateString.AddListener(updateText);
-
-        localizeEvent.RefreshString();
+        viewNameDefaultView.GetComponent<LocalizeStringEvent>().enabled = true;
 
         return defaultViewToDisplay;
     }

--- a/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
+++ b/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
@@ -302,7 +302,19 @@ MonoBehaviour:
   m_FormatArguments: []
   m_UpdateString:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 5529987906244812164}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Text, UnityEngine.UI
+        m_MethodName: set_text
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   references:
     version: 2
     RefIds: []

--- a/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
+++ b/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
@@ -285,7 +285,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3546774875779887096}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 56eb0353ae6e5124bb35b17aff880f16, type: 3}
   m_Name: 

--- a/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
+++ b/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
@@ -292,9 +292,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_StringReference:
     m_TableReference:
-      m_TableCollectionName: 
+      m_TableCollectionName: GUID:d12d872ce99d54eb4977c7b9daa8702f
     m_TableEntryReference:
-      m_KeyId: 0
+      m_KeyId: 245617442938880
       m_Key: 
     m_FallbackState: 0
     m_WaitForCompletion: 0

--- a/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
+++ b/Maker/Assets/Prefabs/Overlay Scroll read only and icon.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Default View
+  m_Text: View
 --- !u!114 &7098116053350033052
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
+++ b/Maker/Assets/Tables/TwinLocalTables Shared Data.asset
@@ -203,6 +203,10 @@ MonoBehaviour:
     m_Key: _NEW_VERSION_
     m_Metadata:
       m_Items: []
+  - m_Id: 76327309114597376
+    m_Key: NEW VIEW
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Maker/Assets/Tables/TwinLocalTables_de.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_de.asset
@@ -213,6 +213,10 @@ MonoBehaviour:
     m_Localized: ' Neue Version '
     m_Metadata:
       m_Items: []
+  - m_Id: 76327309114597376
+    m_Localized: Neue Ansicht
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:

--- a/Maker/Assets/Tables/TwinLocalTables_de.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_de.asset
@@ -81,7 +81,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245617442938880
-    m_Localized: Standardansicht
+    m_Localized: Hauptansicht
     m_Metadata:
       m_Items: []
   - m_Id: 245356280406016

--- a/Maker/Assets/Tables/TwinLocalTables_demed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_demed.asset
@@ -213,6 +213,10 @@ MonoBehaviour:
     m_Localized: ' Neue Version '
     m_Metadata:
       m_Items: []
+  - m_Id: 76327309114597376
+    m_Localized: Neue Ansicht
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:

--- a/Maker/Assets/Tables/TwinLocalTables_demed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_demed.asset
@@ -85,7 +85,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245617442938880
-    m_Localized: Patientenansicht
+    m_Localized: Frontalansicht
     m_Metadata:
       m_Items: []
   - m_Id: 245775882772480

--- a/Maker/Assets/Tables/TwinLocalTables_en.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_en.asset
@@ -213,6 +213,10 @@ MonoBehaviour:
     m_Localized: ' New Version '
     m_Metadata:
       m_Items: []
+  - m_Id: 76327309114597376
+    m_Localized: New View
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:

--- a/Maker/Assets/Tables/TwinLocalTables_enmed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_enmed.asset
@@ -85,7 +85,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 245617442938880
-    m_Localized: Patient view
+    m_Localized: Frontal view
     m_Metadata:
       m_Items: []
   - m_Id: 245775882772480

--- a/Maker/Assets/Tables/TwinLocalTables_enmed.asset
+++ b/Maker/Assets/Tables/TwinLocalTables_enmed.asset
@@ -213,6 +213,10 @@ MonoBehaviour:
     m_Localized: ' New Version '
     m_Metadata:
       m_Items: []
+  - m_Id: 76327309114597376
+    m_Localized: New view
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:


### PR DESCRIPTION
Default View in View Overlay now has a listener for localization changes with better names for the default view - especially in German.