### PR TITLE
TWIN-377-group-in-overview-isnt-updated-when-switching-twins-or-reseting

### DIFF
--- a/Maker/Assets/Code/GroupDisplay.cs
+++ b/Maker/Assets/Code/GroupDisplay.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 public class GroupDisplay : MonoBehaviour 
@@ -8,7 +6,7 @@ public class GroupDisplay : MonoBehaviour
     private void Update()
     {
         Text currentGroupText = this.gameObject.GetComponent<Text>();
-        if (partmanager.currentGroup != null)
+        if (partmanager.currentGroup != null && partmanager.currentGroup.group != null )
         {
             currentGroupText.text = partmanager.currentGroup.name;  
         }


### PR DESCRIPTION
- changed onEnable() to Update() so current group gets updated after resetting the app
- added second condition to if statement for edge case: if there are no groups and you start the app, partmanager.currentGroup isn't null but partmanager.currentGroup.group is. Without the new second condition, there is an empty string as the current group name instead of "no group"
<img width="1316" alt="Bildschirmfoto 2025-07-01 um 12 51 52" src="https://github.com/user-attachments/assets/0d58ac8f-b6a7-457a-a529-d9096ae0b762" />


