### PR TITLE
TWIN-372-discuss-use-of-EventListeners

### DIFF
--- a/Maker/Assets/Code/Localization/ProfileDateFormatter.cs
+++ b/Maker/Assets/Code/Localization/ProfileDateFormatter.cs
@@ -26,40 +26,5 @@ public class ProfileDateFormatter : MonoBehaviour
         }
     }
 
-    /*private void Start()
-    {
-        Text textComponent = this.gameObject.GetComponent<Text>();
-        string storedDate = textComponent.text.ToString();
-        if (DateTime.TryParse(storedDate, out DateTime dateTime))
-        {
-            formattedLocalizedString = DateFormatter.formatDate(dateTime, localizedDateString);
-            //UpdateDate gets called, when event StringChanged is triggered
-            //parameter value of UpdateString is formatted date-string
-            formattedLocalizedString.StringChanged += UpdateDate;
-            //Triggers display update
-            formattedLocalizedString.RefreshString();
-        }
-        else
-        {
-            Debug.Log("Invalid date format: " + storedDate);
-        }
-
-
-    }
-
-    //prevents UpdateDate of trying to get text component when game object is disabled 
-    private void OnDisable()
-    {
-        formattedLocalizedString.StringChanged -= UpdateDate;
-    }
-
-    private void UpdateDate(string value)
-    {
-        Text textComponent = this.gameObject.GetComponent<Text>();
-        //Update UI with formatted date
-        textComponent.text = value;
-
-    }*/
-
 
 }

--- a/Maker/Assets/Code/Localization/ProfileDateFormatter.cs
+++ b/Maker/Assets/Code/Localization/ProfileDateFormatter.cs
@@ -13,6 +13,21 @@ public class ProfileDateFormatter : MonoBehaviour
 
     private void Start()
     {
+        Text textComponent = gameObject.GetComponent<Text>();
+        string storedDate = textComponent.text.ToString();
+        if (DateTime.TryParse(storedDate, out DateTime dateTime))
+        {
+            formattedLocalizedString = DateFormatter.formatDate(dateTime, localizedDateString);
+            textComponent.text = formattedLocalizedString.GetLocalizedString();
+        }
+        else
+        {
+            Debug.Log("Invalid date format: " + storedDate);
+        }
+    }
+
+    /*private void Start()
+    {
         Text textComponent = this.gameObject.GetComponent<Text>();
         string storedDate = textComponent.text.ToString();
         if (DateTime.TryParse(storedDate, out DateTime dateTime))
@@ -33,10 +48,10 @@ public class ProfileDateFormatter : MonoBehaviour
     }
 
     //prevents UpdateDate of trying to get text component when game object is disabled 
-    /*private void OnDisable()
+    private void OnDisable()
     {
         formattedLocalizedString.StringChanged -= UpdateDate;
-    }*/
+    }
 
     private void UpdateDate(string value)
     {
@@ -44,7 +59,7 @@ public class ProfileDateFormatter : MonoBehaviour
         //Update UI with formatted date
         textComponent.text = value;
 
-    }
+    }*/
 
 
 }

--- a/Maker/Assets/Code/TwinVersionSetter.cs
+++ b/Maker/Assets/Code/TwinVersionSetter.cs
@@ -23,32 +23,6 @@ public class TwinVersionSetter : MonoBehaviour
         inputFieldText.text = formattedString;
         lastFormattedDate = formattedString;
     }
-        /*void Start()
-        {
-
-            DateTime currentDate = DateTime.Now; // getting current Time to put into version input field
-
-            // format the date to current localization settings
-            formattedLocalizedString = DateFormatter.formatDate(currentDate, dateFormat);
-
-            // Subscribe to the StringChanged event
-            formattedLocalizedString.StringChanged += UpdateDate;
-            // Triggers display update
-            formattedLocalizedString.RefreshString();
-        }
-
-        // Event handler method
-        private void UpdateDate(string value)
-        {
-            // Update UI with formatted date
-            inputFieldText.text = value;
-            this.lastFormattedDate = value;
-        }
-
-        private void OnDisable()
-        {
-            formattedLocalizedString.StringChanged -= UpdateDate;
-        }*/
 
     public string GetLastFormattedDate()
     {

--- a/Maker/Assets/Code/TwinVersionSetter.cs
+++ b/Maker/Assets/Code/TwinVersionSetter.cs
@@ -12,32 +12,43 @@ public class TwinVersionSetter : MonoBehaviour
     private LocalizedString formattedLocalizedString;
     private string lastFormattedDate;
     // Start is called before the first frame update
-    void Start()
+    void OnEnable()
     {
 
         DateTime currentDate = DateTime.Now; // getting current Time to put into version input field
 
         // format the date to current localization settings
         formattedLocalizedString = DateFormatter.formatDate(currentDate, dateFormat);
-
-        // Subscribe to the StringChanged event
-        formattedLocalizedString.StringChanged += UpdateDate;
-        // Triggers display update
-        formattedLocalizedString.RefreshString();
+        string formattedString = formattedLocalizedString.GetLocalizedString();
+        inputFieldText.text = formattedString;
+        lastFormattedDate = formattedString;
     }
+        /*void Start()
+        {
 
-    // Event handler method
-    private void UpdateDate(string value)
-    {
-        // Update UI with formatted date
-        inputFieldText.text = value;
-        this.lastFormattedDate = value;
-    }
+            DateTime currentDate = DateTime.Now; // getting current Time to put into version input field
 
-    private void OnDisable()
-    {
-        formattedLocalizedString.StringChanged -= UpdateDate;
-    }
+            // format the date to current localization settings
+            formattedLocalizedString = DateFormatter.formatDate(currentDate, dateFormat);
+
+            // Subscribe to the StringChanged event
+            formattedLocalizedString.StringChanged += UpdateDate;
+            // Triggers display update
+            formattedLocalizedString.RefreshString();
+        }
+
+        // Event handler method
+        private void UpdateDate(string value)
+        {
+            // Update UI with formatted date
+            inputFieldText.text = value;
+            this.lastFormattedDate = value;
+        }
+
+        private void OnDisable()
+        {
+            formattedLocalizedString.StringChanged -= UpdateDate;
+        }*/
 
     public string GetLastFormattedDate()
     {


### PR DESCRIPTION
-ProfileDateFormatter.cs: formats the creation date of twins/versions in SaveUI/Twin versions UI. Because it is only necessary to format it once (when the prefab gets built), I removed the event listener and added the functionality to the Start() method
-TwinVersionSetter.cs: sets the text in the input field in Twin versions UI. Same thing as ProfileDateFormatter with the difference that the text needs to be set every time the page gets opened so I used OnEnable() instead of Start()